### PR TITLE
Add vgr-design Claude Code skill

### DIFF
--- a/.claude/skills/vgr-design/DESIGN_SYSTEM.md
+++ b/.claude/skills/vgr-design/DESIGN_SYSTEM.md
@@ -1,0 +1,338 @@
+# VGR Designsystem
+
+Sammanställt från Västra Götalandsregionens digitala designmanual. Källa: skärmdumpar från designsystem-sajten (Notion). Manualen är märkt "under uppbyggnad" — vissa avsnitt saknas eller är "In progress"/"To do" (se `SAKNAS.md`).
+
+Den här filen är referens för Claude när nya VGR-webbappar eller appar byggs. Allt nedan ska följas om inget annat överenskommits.
+
+---
+
+## Designprinciper
+
+1. **För och med människor** — empati först, involvera användare från start, undvik att gissa behov, validera kvalitativt och kvantitativt.
+2. (Återstående principer saknas i fångade screenshots — se `SAKNAS.md`.)
+
+---
+
+## Grundstenar
+
+### Logotyp
+- Två varianter: **lång** (Västra Götalandsregionen) och **kort** (VGR-symbolen).
+- Enbart symbolen används på **minimala digitala ytor** (favicon, app-ikon) där varken lång eller kort version är läsbar.
+- På tydligt VGR-gränssnitt kan primärfärger användas som bakgrund med vit ikon ovanpå; annars **svart ikon på vit bakgrund**.
+- Får placeras på bakgrund med VGR:s **form** (grundform/komplementform).
+
+### Färg
+**Färgsystem:** 3 färgroller × nyanser.
+- **Primärfärg** — 3 nyanser: ★ (varumärke) + 1 steg mörkare + 90 + 95.
+- **Komplementfärg 1** ("Healthcare"-serien) — 2 nyanser: 80, 95.
+- **Komplementfärg 2** — 2 nyanser: 80, 95.
+- ★ = färger från varumärkesprofilen.
+- Utöver dessa: fler komplementfärger för grafer eller objektfärgning.
+
+**Bekräftade värden:**
+- `Base 20` = `#273238` (mörkaste primärfärgens nyans).
+- `Healthcare 40` = länkfärg i brödtext (hex TBD).
+
+**Regler:**
+- Använd **endast färg från gråskalan eller komplementpaletten på text**.
+- Reservera **inte färger** för enskilt projekt.
+- **Inte enda faktorn** i en design (tillsammans med ikon/typografi).
+- Tillgodose **fler kan se** din design — välj färger med tillräcklig kontrast enligt DOS-lagen.
+- Skapa sammanhållet intryck: max ~4 huvudfärger utöver funktionella (status, diagram, varningar).
+
+### Färgteman (extern webb)
+- Ett "grundtema" = 3 färger + flera nyanser.
+- Markera funktionella färger (status, varning) separat från brand.
+
+### Typsnitt
+- **Webb:** `Verdana` (ersättning för varumärkestypsnittet VGR Sans).
+- **iOS:** `SF Pro` (systemtypsnitt).
+- **Android:** `Roboto` (systemtypsnitt).
+
+**iOS-typografi-skala (exakta värden från manualen):**
+| Stil          | Storlek | Vikt     | Line-height |
+|---------------|---------|----------|-------------|
+| Large title   | 34      | Bold     | 41          |
+| Title 1       | 28      | Bold     | 34          |
+| Title 2       | 22      | Bold     | 28          |
+| Title 3       | 20      | Bold     | 25          |
+| Headline      | 17      | Semibold | 22          |
+| Body          | 17      | Regular  | 22          |
+| Callout       | 16      | Regular  | 21          |
+| Subhead       | 15      | Regular  | 20          |
+| Footnote      | 13      | Regular  | 18          |
+| Caption 1     | 12      | Semibold | 16          |
+| Caption 2     | 11      | Regular  | 13          |
+
+> **Webb-skalan saknas** i fångade screenshots — använd defaults i `tokens.json/tokens.css` tills officiell skala kan hämtas.
+
+### Form (varumärkesform)
+- **Grundform** används som bakgrund till större ytor/bilder där form inte bryter standarder (t.ex. inmatningsfält).
+- **Radie** sätts utifrån elementets bredd — större bredd = större radie.
+- När flera former möts: placera radien på det hörn som skapar **mellanrumsformer**.
+- Komponenter som hör ihop ska ha **samma radie** (för enhetligt intryck).
+- Undvik så liten radie att mellanrumsformerna blir otydliga.
+- Komplementformer används som bakgrund för ikoner eller för att lyfta splash/illustrationer.
+
+### Bilder
+- **Undvik text i bild** (placera text i layouten istället).
+- **Lägg inte in former i bilden** — låt gränssnittet hantera formen. Undantag: externa gränssnitt (App Store) där identitet inte syns annars.
+- Tänk på bildens utskärning utifrån användning (helbild vs. klickbar mer-vy).
+- Använd rätt format/filstorlek.
+- Håll enhetligt bildförhållande.
+- **Alltid `alt`-text.**
+- För mer detalj: VGR:s varumärkesmanual → `/ov/varumarkesmanual/bild/`.
+
+### Ikoner & illustrationer
+- Designsystemets ikonbibliotek baseras på:
+  - **SF Symbols** — använder iOS standard-systemikoner (chevron, profil etc.). Inte justerbara/valbara i designsystemet.
+  - **Streamline Regular 3.0** — egna ikoner för **huvudmeny och inom UI**.
+  - **Streamline Bold 3.0** — egna ikoner för att **tillverka app-ikoner**.
+- Exempel-ikoner i manualen: Graph, Headphones, Heart, Heart with puls m.fl.
+
+---
+
+## Layout
+
+### Marginaler / spacing
+| Storlek   | Värde    | Användning |
+|-----------|----------|------------|
+| Small     | 4/8/12px | Inom samma komponent |
+| Medium    | 24px     | Mellan komponenter i samma grupp (grid-gap) |
+| Large     | 32px     | Mellan grupper / större delar (footer/content, två innehållsareor) |
+| Safearea  | 24px     | Minsta padding i sidorna av en webbsida |
+
+### Breakpoints
+- **Mobil**: 320–768 px
+- **iPad/tablet**: 768–1200 px
+- **Desktop**: 1200–1920 px
+- **Komponentens min-bredd före breakpoint-fall**: 220 px
+- **Max komponenter per rad**: 4 + vänstermeny
+- En innehållsarea innehåller max 4 komponenter.
+- Om innehållsarean har bakgrundsfärg ska element ovanpå vara vita och inte ha annan bakgrundsfärg. Default bakgrund = utan färg = komplement 95.
+
+---
+
+## Komponenter (webb)
+
+Varje komponent har minst tillstånden Default, Hover, Focus, Disabled där det är meningsfullt.
+
+### Knapp
+- **Primär:** mörkblå/mörk bakgrund, vit text, valbar ikon. States: Default, Hover (svart bakgrund), Disabled (grå).
+- **Sekundär:** outline-variant av samma form.
+- Properties: `type` (Primary/Secondary), `state`, `inverted` (true/false för mörk yta), `showIcon`, `text`.
+
+### Länkar
+- I brödtext: färg `Healthcare 40` + **understruken**.
+- States: Default, Hover, Focus (mörk highlight-bakgrund), Visited, Disabled.
+- Länkar utan understrykning markeras med **ikon** för att signalera tryckbarhet (affordance).
+- Ikon för länk till **annan webbplats** placeras efter länktexten, läses upp av skärmläsare.
+
+### Länkikoner
+- Förtydligar typ av länk i en lista.
+- Får inte användas på löpande text eller textstycken — bara på rena länkar.
+- **Före** länktexten (utom "extern webbplats"-ikon som ligger **efter**).
+- En länk = en ikon.
+
+### Taggar
+- **Informationstaggar:** Alarm (röd), Varning (gul), Success (grön), Neutral (grå).
+- **Aktiva filtertaggar:** "Filter ✕" på olika bakgrunder (on color / on white). Hover/Focus visar tydlig avlägsna-affordance.
+
+### Inputfält
+- Desktop: söklåda + sökknapp ("Vad letar du efter?" placeholder).
+- States: Default, Hover, Focus.
+- Variant: Input + scope-knapp (`Show scope: yes`).
+
+### Checkbox
+- States: Unchecked, Checked, Hover, Focus, Disabled checked, Disabled unchecked, **Indeterminate** (streck), **Partial** (square).
+- Mörk bakgrund + vit bock i checked.
+
+### Toggle
+- States: On default, Off default, On disabled, Off disabled, Focus (med focus-ring).
+- Pill-form med cirkel som glider; mörkblå när on.
+
+### Tabs
+- **Default:** horisontell bar med flikar; "Fler…" dropdown vid överskott.
+- **Vertikal:** flikar i lista.
+- **Active:** mörk pill-bakgrund + vit text.
+- Visa antal i parentes vid behov: `Tab title (31)`.
+
+### Dropdown
+- States: Default, Hover, Focus, **Warning** ("Obligatoriskt fält" i rött).
+- Rubrik ovanför + dropdown-block under.
+- Properties: `showLabel`, `showList`, `showIcon`.
+- **Multiselect**-variant med chips inne i fältet + filtrerbar lista (Filterintervall).
+
+### Datumväljare
+- Desktop: rubrik + ikon + `åååå-mm-dd` placeholder.
+- **One field** (enskilt datum) eller **Two fields** (datumintervall, två rutor med avgränsare).
+- Properties: `showLabels`, `showDividers`.
+- Egen mobil-design.
+
+### Toggle filter
+- Inkludera/exkludera källor (t.ex. i ett sök).
+- Står som rad med toggle till höger + sekundär metainfo under.
+- Variant: **Toggle filter block** med "Submenu title" + lista av toggles.
+
+### Flervalsfilter med nivåer
+- Checkboxar med expand/collapse (`Sublevel open - top/bottom`).
+- States: default, checked, sublevel open (top/bottom), checked.
+- Property `Property 1: Sublevel top/bottom`.
+
+### Expanderbart block (mindre)
+- Två utföranden: **Infobrun/Linje**.
+- Två storlekar: **Small/XS**.
+- Används när vanliga expanderbara block är för stora.
+- Properties: `expanded` (true/false), `topBorder` (true/false).
+- Expanderat block visar inomliggande brödtext.
+
+### Help button / Help box
+- **Help button**: enkel `?`-ikon. States: Default, Hover, Focus.
+- **Help box**: expanderad informationsruta med rubrik + brödtext + ✕-knapp. States: Default, Hover.
+
+### Paginering
+- **Default:** "‹ Föregående  1 2 3 … 9  Nästa ›" i pill-knappar; aktuell sida mörkfylld.
+- **Small:** bara siffror + pilar (ingen text).
+- **Mini:** enbart pilar.
+- Om ingen föregående/nästa-sida finns visas pilen som disabled.
+
+### Callouts / varningar
+- **Alarm:** röd vänsterram, ljusrosa bakgrund, varningsikon.
+- **Info:** grå/blå vänsterram, ljusgrå bakgrund, info-ikon.
+- **Varning – Centrerad:** gul vänsterram, ljusgul bakgrund.
+- Brödtext + ev. länk i texten.
+
+### Tabs / Sökresultat / Sökträffar / Nollträffar / Artikel
+- **Sökresultat:** lista med antal träffar, scope, kategorier, sorteringsval (Relevans, Publiceringsdatum, A–Ö). Properties styr om filter/scope/sortering visas. Egen desktop/mobil-layout.
+- **Sökträff (enskild):** Ikon + rubrik + informations-tagg + datum + bullets med metadata + brödtext + "Visa mer uppgifter ▾" toggle. Varianter för webbsidor, dokument, jobbannonser, personer.
+- **Nollträffar (Large):** rubrik "Din sökning på 'X' gav inga träffar" + alternativ ("Vill du istället söka på …") + söktips för dokument + generella söktips + illustration + länk för förbättringsförslag.
+- **Artikel:** rubrik, brödtext, inbäddade bilder, h2/h3-rubriker, fortsatt brödtext.
+
+### Huvudmeny (webb)
+- **Desktop:** logotyp till vänster + topplänkar (Om, Grundstenar, Webb, Appar) + sök till höger. Variant **Med underrubrik** under huvudtitel + bredare topmeny med ikoner (Logotyper, Tecknetolkning, Press, Webbplatskartan, Tillgänglighet, Sök).
+- **Mobil:** hamburgermenystruktur.
+
+---
+
+## Komponenter (iOS)
+
+### iOS-knappar
+- **Primär:** fylld med primärfärg + ikon + "Knapptext". States: Default light/dark, Disabled light/dark.
+- **Sekundär:** outline-variant.
+- Varianter för light- och dark-mode parallellt.
+
+### iOS-kort (Card)
+- **Default Card:** bild + rubrik + meta + flagga (i hörn).
+- Properties: `mediaType` (Image/Thumbnail/Icon), `showDetail`, `showFlag`, `showImage`, `darkMode`.
+- Varianter: **Tumnagel**, **Slim med foto**, **Slim med ikon**, plus deras dark-mode versioner.
+
+### iOS-callout
+- Variant **Information med ikon**, **Information med illustration**, samt Light/Dark mode.
+- Innehåller rubrik + brödtext + primärknapp.
+
+### iOS Text Formulär
+- **Text fält:** Default, Aktivt, Skriver, Skrivit.
+- **Text area:** samma states.
+- Rubrik + Placeholder + beskrivning under.
+
+### iOS Huvudmeny / Trender / App Store
+- Egna mönster i manualen (sidorna har detaljerade riktlinjer).
+
+---
+
+## Komponenter (Android)
+
+- App-ikoner: rektangulära 1024×1024 utan runda hörn (Android-OS lägger på rundningen). Säkerställ att VGR-logotyper **inte skärs av** i runda Android-varianter.
+- Onboarding: separat Android-template, samma flöde (flera steg vs. ett steg).
+
+---
+
+## Mönster
+
+### Onboarding (iOS/Android)
+- Två templates: **Flera steg** (med stegindikator) och **Bara ett steg** (utan indikator).
+- Ge möjlighet att hoppa över.
+- Visa tydligt steg X av Y.
+
+### Rensa filter
+- Egen sida i manualen — knapp som rensar aktiva filtertaggar.
+
+### App Store / Google Play
+- Egna riktlinjer för App Store-bilder och Google Play-bilder.
+
+---
+
+## Tillgänglighet
+
+**Lagkrav:** DOS-lagen + WCAG.
+
+**Användare som ska kunna använda gränssnittet:**
+- Utan eller med nedsatt syn.
+- Utan färgseende.
+- Utan eller med nedsatt hörsel.
+- Utan att kunna använda rösten.
+- Med begränsad motorik.
+- Med begränsad räckvidd.
+- Utan att utsättas för ljusflimmer.
+- Med nedsatt kognitiv förmåga.
+
+**Riktlinjer (översikt):**
+- **Tangentbord:** ska fungera med tangentbord (alla interaktiva element nåbara, synlig focus).
+- **Kontraster:** kontraster ska vara bra; särskilt på stortext, interaktiva objekt, text på bakgrund.
+- **Skärmläsare:** beakta uppläsningsordning, alt-text, ARIA, ikon-vs-text.
+
+**Hjälpmedel att stödja:** skärmläsare, punktskriftsvisning, zoom, text-till-tal, taligenkänning, alternativa tangentbord.
+
+**Skärmläsare att testa med:**
+- VoiceOver för iOS
+- TalkBack för Android
+- NVDA (Windows)
+- JAWS (Windows)
+- iOS Voice Control
+- Android Voice Access
+
+**Testverktyg:**
+- WAVE (uppskattningsverktyg för webbinnehåll)
+- Kolla kontrast (Webaim)
+- Tillgänglighetsinspektorn (iOS / macOS)
+
+---
+
+## Text (UX-copy)
+
+### Klarspråk
+- **Vårdat, enkelt, begripligt språk** — anpassat efter målgrupp.
+- Stäm av med mottagarens förkunskaper, förväntningar, kunskapsnivå.
+- Var tydlig med varför texten skrivs och vad den ska uppnå.
+- Tänk på att användare ofta kommer direkt in via sökmotor — texter måste begripas både på egen hand och i sitt sammanhang.
+- Referenser: Myndigheternas skrivregler, "Att skriva för webben", VGR:s varumärkesmanual.
+
+### Röst
+- VGR:s personlighet och röst — separat avsnitt i manualen (ej fångad i screenshots).
+
+### Tonalitet
+- Hur tonen anpassas till sammanhang — separat avsnitt (ej fångad).
+
+---
+
+## Affordance (klickbarhet)
+
+- Det måste **synas** att något går att klicka på. Användare ska inte behöva gissa.
+- Länkar/tryckbara texter ska alltid markeras med **understrykning eller ikon**.
+- Länkar i brödtext: alltid `Healthcare 40` + understruken.
+- Knappar/länkar som inte ser klickbara ut → risk att användaren missar viktiga delar.
+
+---
+
+## Design-tokens (struktur)
+
+Tokens grupperas i kategorier (från manualens token-flikar — endast intro-fliken var fångad):
+- **Accent** — accentfärger
+- **Neutral** — gråskala
+- **Inverted** — för mörka teman
+- **Fixed** — fasta värden som inte byter med tema
+- **Graphic** — graffärger
+- **Status** — alarm/info/varning/success
+- **Elevation** — skuggor/höjd
+
+> Innehållet i varje flik är **inte fångat** i screenshots och måste hämtas från manualen direkt.

--- a/.claude/skills/vgr-design/SAKNAS.md
+++ b/.claude/skills/vgr-design/SAKNAS.md
@@ -1,63 +1,36 @@
 # Luckor i extraherat material
 
-Det här är vad jag **inte** har kunnat extrahera från screenshots/PDF. Be om Figma-fil, en titt på originalet, eller bekräftade värden för att fylla i.
+**Senast uppdaterad:** 2026-05-22 efter att hela tokenpaletten extraherats från `designsystem-ios` (92 färger × light/dark).
 
-**Senast uppdaterad:** 2026-05-22 efter att Färgteman-PDF:en kompletterade hela färgpaletten.
+## ✅ Löst sedan tidigare
+- **Färgpalett:** komplett — Primary, Neutral, Status, Accent (10 färger × 5 roller), Elevation, Customized.
+- **Dark mode:** alla 92 tokens har både light och dark värde.
+- **Status-tokens:** error/warning/information/success med text+surface-par.
+- **Text-tokens:** finns nu (text, textvariant, textfixed, textinverted, textdisabled) med exakta värden.
+- **Elevation:** 5 nivåer + background med både light/dark.
 
-## Färg — ✅ KOMPLETT FRÅN PDF
-- Base 20/30/90/95 — klart
-- Culture 30/40/90/95 — klart
-- Education 30/40/90/95 — klart
-- Healthcare 30/40/90/95 — klart
-- Brown 80/95, Healthcare 80/95, Pink 80/95, Yellow 80/95 — klart
-- Brown 99 (bakgrund), Neutral 100 — klart
+## Kvarstår
 
-## Färg — kvarstår
-- **Textfärger** (primary, secondary, inverse, disabled) — manualen säger "Textfärgerna används i Figma i komponenter och är där kontrastcheckade i den kontext de presenteras" men hex-värden för enskilda text-tokens listas inte. Hämta från Figma.
-- Status-tokens — kontrollera om manualen har separata alarm/warning/info/success utöver att återanvända Culture/Yellow/Base/Education. Just nu mappas semantiska alias i `tokens.css`.
-- Tokens-flikar i designmanualen — endast "Introduktion" var fångad i screenshots. Flikarna **Accent, Neutral, Inverted, Fixed, Graphic, Status, Elevation** har inte fångats — där kan det finnas fler namngivna tokens med specifika roller (border, surface, overlay, focus-ring etc).
+### Typografi
+- **Webbskala** (h1–h6, body, small): manualens officiella värden saknas. iOS-skalan finns komplett.
+- **Android-skala:** Material 3-mappning saknas (ingen `designsystem-android`-repo finns).
+- Specifik fontvikt-användning för Verdana på webb.
 
-## Typografi
-- **Webbskala** — h1/h2/h3/h4/body/small specifika storlekar, vikter och line-heights. Endast iOS-skalan är fångad. Defaults används tills officiell skala kommer.
-- **Android-skala** — Material 3-mappning saknas.
-- Specifik fontvikt-användning (när Verdana bold vs regular).
+### Komponentdetaljer
+- Exakta paddings/höjder per komponent (kan extraheras ur iOS-paketets SwiftUI-kod — gör vid behov).
+- Webb-komponentexempel — manualen visar skärmdumpar, ej kod.
+- Designprinciper 2–N (bara princip 1 fångad i screenshots).
 
-## Komponenter
-- Knapp: exakta paddings, höjder, ramfärger per state (hex för Primär/Sekundär).
-- Inputfält: storlekar, paddings, ramfärger per state.
-- Tabs, Dropdown, Datumväljare: exakt storlek/padding/font-vikt.
-- Webb-kort — manualen verkar inte ha eget kort-mönster för webb (bara iOS Card). Bekräfta.
-- "Mönster"-sektionen utöver Nollträffar och Huvudmeny — fler sidor finns men ej fångade.
+### Övrigt
+- **Tonalitet / röst** — bara titel synlig i manualen.
+- **WCAG-riktlinjer** — bara översikt, ej konkreta kontrastkrav (men tokens är redan kontrastcheckade i sina semantiska par).
+- **Motion tokens** — manualen anger inga. Defaults gissade i `tokens.json`.
+- **Radievärden i pixlar per komponent** — bara principen "större bredd = större radie" finns.
 
-## Designprinciper
-- Princip 2–N saknas (bara princip 1 "För och med människor" är fångad).
+## Vad som INTE är canonical
+- `github.com/Vastra-Gotalandsregionen/komponentkartan` — ÄLDRE intern admin-style (Calibri, andra färger). Använd inte för publika appar.
 
-## Text / röst
-- "Röst"-sidan (VGR:s personlighet) — bara titel synlig, inget innehåll.
-- "Tonalitet"-sidan — bara titel.
-
-## Tillgänglighet
-- WCAG-sidan: bara "Under arbete" + bullet-lista över användartyper.
-- Riktlinjer → Tangentbord / Kontraster / Skärmläsare: bara översikt med rubriker.
-- "Testa tillgänglighet för appar" — sida finns men innehåll ej fångat.
-
-## Motion
-- Inga motion tokens i fångat material — defaults i `tokens.json` är gissade.
-
-## Form (varumärket)
-- Konkreta radie-värden i pixlar per komponentstorlek saknas. Endast principen "större bredd = större radie" är fångad.
-
----
-
-## Hur du fyller i
-1. Hämta exakt värde från Figma eller designsystem-sajten.
-2. Lägg in i `tokens.json` (ta bort `"TBD"`).
-3. Uppdatera `tokens.css` med motsvarande variabel.
-4. Stryk raden här.
-
-## Tips: skicka mer som PDF
-Det enklaste sättet att fylla i luckor är att exportera relevanta sidor från manualen som PDF (precis som Färgteman-PDF:en) och dela. Jag kan läsa dem direkt och uppdatera systemet. Prioriterade sidor:
-- **Design Tokens-flikar** (Accent/Neutral/Inverted/Fixed/Graphic/Status/Elevation)
-- **Typsnitt** (för webbskalan — om den finns)
-- **Tonalitet** och **Röst**
-- **WCAG-riktlinjer** (Tangentbord/Kontraster/Skärmläsare)
+## Hur du fyller i kvarvarande
+1. **Webb-typskala:** exportera Typsnitt-sidan från manualen som PDF.
+2. **Komponentdetaljer:** dra exakta värden ur iOS-paketet (`Sources/DesignSystem/Views/*.swift`) per behov.
+3. **WCAG / motion:** fråga VGR designteam eller exportera relevanta sidor.

--- a/.claude/skills/vgr-design/SAKNAS.md
+++ b/.claude/skills/vgr-design/SAKNAS.md
@@ -1,0 +1,63 @@
+# Luckor i extraherat material
+
+Det här är vad jag **inte** har kunnat extrahera från screenshots/PDF. Be om Figma-fil, en titt på originalet, eller bekräftade värden för att fylla i.
+
+**Senast uppdaterad:** 2026-05-22 efter att Färgteman-PDF:en kompletterade hela färgpaletten.
+
+## Färg — ✅ KOMPLETT FRÅN PDF
+- Base 20/30/90/95 — klart
+- Culture 30/40/90/95 — klart
+- Education 30/40/90/95 — klart
+- Healthcare 30/40/90/95 — klart
+- Brown 80/95, Healthcare 80/95, Pink 80/95, Yellow 80/95 — klart
+- Brown 99 (bakgrund), Neutral 100 — klart
+
+## Färg — kvarstår
+- **Textfärger** (primary, secondary, inverse, disabled) — manualen säger "Textfärgerna används i Figma i komponenter och är där kontrastcheckade i den kontext de presenteras" men hex-värden för enskilda text-tokens listas inte. Hämta från Figma.
+- Status-tokens — kontrollera om manualen har separata alarm/warning/info/success utöver att återanvända Culture/Yellow/Base/Education. Just nu mappas semantiska alias i `tokens.css`.
+- Tokens-flikar i designmanualen — endast "Introduktion" var fångad i screenshots. Flikarna **Accent, Neutral, Inverted, Fixed, Graphic, Status, Elevation** har inte fångats — där kan det finnas fler namngivna tokens med specifika roller (border, surface, overlay, focus-ring etc).
+
+## Typografi
+- **Webbskala** — h1/h2/h3/h4/body/small specifika storlekar, vikter och line-heights. Endast iOS-skalan är fångad. Defaults används tills officiell skala kommer.
+- **Android-skala** — Material 3-mappning saknas.
+- Specifik fontvikt-användning (när Verdana bold vs regular).
+
+## Komponenter
+- Knapp: exakta paddings, höjder, ramfärger per state (hex för Primär/Sekundär).
+- Inputfält: storlekar, paddings, ramfärger per state.
+- Tabs, Dropdown, Datumväljare: exakt storlek/padding/font-vikt.
+- Webb-kort — manualen verkar inte ha eget kort-mönster för webb (bara iOS Card). Bekräfta.
+- "Mönster"-sektionen utöver Nollträffar och Huvudmeny — fler sidor finns men ej fångade.
+
+## Designprinciper
+- Princip 2–N saknas (bara princip 1 "För och med människor" är fångad).
+
+## Text / röst
+- "Röst"-sidan (VGR:s personlighet) — bara titel synlig, inget innehåll.
+- "Tonalitet"-sidan — bara titel.
+
+## Tillgänglighet
+- WCAG-sidan: bara "Under arbete" + bullet-lista över användartyper.
+- Riktlinjer → Tangentbord / Kontraster / Skärmläsare: bara översikt med rubriker.
+- "Testa tillgänglighet för appar" — sida finns men innehåll ej fångat.
+
+## Motion
+- Inga motion tokens i fångat material — defaults i `tokens.json` är gissade.
+
+## Form (varumärket)
+- Konkreta radie-värden i pixlar per komponentstorlek saknas. Endast principen "större bredd = större radie" är fångad.
+
+---
+
+## Hur du fyller i
+1. Hämta exakt värde från Figma eller designsystem-sajten.
+2. Lägg in i `tokens.json` (ta bort `"TBD"`).
+3. Uppdatera `tokens.css` med motsvarande variabel.
+4. Stryk raden här.
+
+## Tips: skicka mer som PDF
+Det enklaste sättet att fylla i luckor är att exportera relevanta sidor från manualen som PDF (precis som Färgteman-PDF:en) och dela. Jag kan läsa dem direkt och uppdatera systemet. Prioriterade sidor:
+- **Design Tokens-flikar** (Accent/Neutral/Inverted/Fixed/Graphic/Status/Elevation)
+- **Typsnitt** (för webbskalan — om den finns)
+- **Tonalitet** och **Röst**
+- **WCAG-riktlinjer** (Tangentbord/Kontraster/Skärmläsare)

--- a/.claude/skills/vgr-design/SKILL.md
+++ b/.claude/skills/vgr-design/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: vgr-design
+description: "Use when building or extending a web app or mobile app that must follow the Vastra Gotalandsregionen (VGR) design system. Triggers on requests like build a VGR app, new page in VGR style, add a component that follows VGR, or any work in a folder marked VGR or Vastra Gotalandsregionen. Loads tokens, component rules and accessibility requirements from the local design system files."
+---
+
+# VGR Designsystem — användning
+
+När den här skillen aktiveras: läs in följande filer **innan** du skriver kod eller markup. Filerna ligger i samma mapp som denna `SKILL.md`:
+
+1. `./DESIGN_SYSTEM.md` — full komponent- och regelreferens.
+2. `./tokens.json` — kanoniska tokenvärden.
+3. `./tokens.css` — CSS-variabler att kopiera/importera i projektet.
+4. `./SAKNAS.md` — kända luckor; om en lucka påverkar arbetet, fråga användaren innan du gissar.
+
+## Regler för all kod du skriver i VGR-projekt
+
+**Färg**
+- Använd endast tokens från `tokens.css` (eller motsvarande mappning till projektets ramverk). Hårdkoda aldrig hex-värden.
+- Färg får inte vara enda informationsbäraren — komplettera alltid med ikon, text eller form.
+- Länkar i brödtext: `Healthcare 40` + understruken.
+- Använd endast färg från gråskalan eller komplementpaletten på text.
+
+**Typografi**
+- Webb: `Verdana, sans-serif`.
+- iOS: `SF Pro` med iOS-typskalan i `tokens.json` (Large title 34 → Caption 2 11).
+- Android: `Roboto` (Material 3 type-skala).
+- Använd aldrig VGR Sans i digitala gränssnitt.
+
+**Spacing & layout**
+- Spacing: 4/8/12 (small), 24 (medium, mellan komponenter), 32 (large, mellan grupper). Safearea = 24.
+- Breakpoints: mobil 320–768, tablet 768–1200, desktop 1200–1920.
+- Min komponentbredd innan breakpoint-fall: 220px.
+- Max 4 komponenter per rad (+ vänstermeny). Max 4 komponenter per innehållsarea.
+
+**Radier**
+- Sätts utifrån elementets bredd — större element, större radie.
+- Komponenter som hör ihop ska ha samma radie.
+- När flera former möts: placera radien på det hörn som skapar mellanrumsformer.
+
+**Komponenter — välj alltid från manualen**
+Knapp, Länk, Länkikon, Tagg, Inputfält, Checkbox, Toggle, Tabs, Dropdown, Datumväljare, Toggle filter, Flervalsfilter med nivåer, Expanderbart block, Help button/box, Paginering, Callout/varning, Sökresultat, Sökträff, Nollträff, Artikel, Huvudmeny. För iOS finns dessutom Card, Callout-iOS, Text Formulär-iOS, Knappar-iOS. För Android: separata App-ikon-regler.
+
+Bygg inga "egna" varianter av etablerade komponenter — utöka istället en befintlig med en ny prop/state efter att ha kontrollerat med användaren.
+
+**Tillgänglighet (icke förhandlingsbart)**
+- WCAG 2.1 AA + DOS-lagen.
+- Tangentbordsnavigerbart med synlig focus.
+- Korrekta kontraster.
+- Klickbarhet ska synas (understrykning eller ikon).
+- Alltid `alt`-text på bilder.
+- Använd inte text i bilder.
+- Testa mot VoiceOver (iOS), TalkBack (Android), NVDA/JAWS.
+
+**Klarspråk**
+- Vårdat, enkelt, begripligt språk anpassat efter målgrupp.
+- Texter ska gå att förstå även utan föregående kontext (användare kommer ofta direkt från sökmotor).
+
+## När något saknas
+
+Om token, färgvärde eller komponent inte finns i `tokens.json`/`DESIGN_SYSTEM.md`:
+1. Slå upp i `SAKNAS.md`.
+2. Fråga användaren om värdet (eller om TBD-default kan användas).
+3. Föreslå aldrig hex-värden på egen hand utan att flagga att de är gissade.
+
+## Output-format
+
+Föreslå default React + Tailwind, men följ alltid projektets befintliga val. Mappa tokens till:
+- Tailwind: konfigurera i `tailwind.config.js` så `bg-vgr-primary-base20` etc. fungerar.
+- Plain CSS: importera `tokens.css` och använd `var(--vgr-*)`.
+- iOS (SwiftUI): definiera `Color.vgrPrimaryBase20` osv. i `Tokens.swift`.
+- Android (Compose): definiera i `Color.kt` / `Theme.kt`.

--- a/.claude/skills/vgr-design/SKILL.md
+++ b/.claude/skills/vgr-design/SKILL.md
@@ -1,71 +1,101 @@
 ---
 name: vgr-design
-description: "Use when building or extending a web app or mobile app that must follow the Vastra Gotalandsregionen (VGR) design system. Triggers on requests like build a VGR app, new page in VGR style, add a component that follows VGR, or any work in a folder marked VGR or Vastra Gotalandsregionen. Loads tokens, component rules and accessibility requirements from the local design system files."
+description: "Use when building or extending a web app or mobile app that must follow the Vastra Gotalandsregionen (VGR) design system. Triggers on requests like build a VGR app, new page in VGR style, add a component that follows VGR, or any work in a folder marked VGR or Vastra Gotalandsregionen. Loads canonical tokens, component rules and accessibility requirements from the local design system files mirrored from the official iOS Swift Package."
 ---
 
 # VGR Designsystem — användning
 
-När den här skillen aktiveras: läs in följande filer **innan** du skriver kod eller markup. Filerna ligger i samma mapp som denna `SKILL.md`:
+## Canonical sources (rangordnade)
 
-1. `./DESIGN_SYSTEM.md` — full komponent- och regelreferens.
-2. `./tokens.json` — kanoniska tokenvärden.
-3. `./tokens.css` — CSS-variabler att kopiera/importera i projektet.
-4. `./SAKNAS.md` — kända luckor; om en lucka påverkar arbetet, fråga användaren innan du gissar.
+1. **iOS-appar:** `https://github.com/Vastra-Gotalandsregionen/designsystem-ios` — Swift Package. Lägg alltid till som dependency och använd `VGRButton`, `VGRCallout` etc. **Bygg aldrig egna iOS-komponenter när en VGR-komponent finns.**
+2. **Tokens (alla plattformar):** `./tokens-colors.json` (92 färger × light/dark) och `./tokens.json` (typografi, spacing, radier, breakpoints) — speglade direkt från iOS-paketets `Assets.xcassets`.
+3. **Komponentbeskrivningar/regler:** `./DESIGN_SYSTEM.md` (extraherat från designmanualen).
+4. **Webb:** Det finns **ingen** officiell webbkomponent-repo för det moderna designsystemet. (`Vastra-Gotalandsregionen/komponentkartan` är ett **äldre internt admin-system** med annan färgpalett/typografi — använd INTE för publika webbappar.) Bygg webbkomponenter från grunden med tokens i `tokens.css`.
+5. **Android:** Ingen officiell repo. Mappa tokens till Material 3 via `Theme.kt`/`Color.kt`.
 
-## Regler för all kod du skriver i VGR-projekt
+## Läs in dessa filer innan du skriver kod
+
+1. `./DESIGN_SYSTEM.md` — komponentlista, regler, principer.
+2. `./tokens.json` — navigationsguide över tokens.
+3. `./tokens-colors.json` — fullständig färgpalett.
+4. `./tokens.css` — färdiga CSS-variabler (light + dark via `prefers-color-scheme`).
+5. `./SAKNAS.md` — kända luckor; fråga användaren innan du gissar.
+
+## Färgmodell (viktigt)
+
+Tokens grupperas i 6 kategorier:
+- **Primary** — `base` (mörkgrå varumärke) + `blue` (Healthcare/vård) + `action` (semantisk länk/knapp).
+- **Neutral** — text, border, divider, disabled, surface (varianter: variant/fixed/inverted/disabled).
+- **Status** — error / warning / information / success, alltid par av `text` + `surface`.
+- **Accent** — 10 accentfärger (brown, cyan, green, lime, orange, pink, purple, red, yellow) × 5 roller (base, graphic, surface, surfacebold, surfaceminimal) = 50 tokens.
+- **Elevation** — `background` + `elevation1..5` (kritiskt för dark mode).
+- **Customized** — projektsspecifika varianter.
+
+Varje token har **light och dark värde** — använd CSS:s `prefers-color-scheme` (redan inbyggt i `tokens.css`).
+
+## Regler för all kod
 
 **Färg**
-- Använd endast tokens från `tokens.css` (eller motsvarande mappning till projektets ramverk). Hårdkoda aldrig hex-värden.
-- Färg får inte vara enda informationsbäraren — komplettera alltid med ikon, text eller form.
-- Länkar i brödtext: `Healthcare 40` + understruken.
-- Använd endast färg från gråskalan eller komplementpaletten på text.
+- Använd alltid token-variabler (`var(--vgr-primary-action)`, `Color("primary/action")` osv). Aldrig hex.
+- Färg får inte vara enda informationsbäraren — komplettera med ikon, text eller form.
+- Länkar i brödtext: `--vgr-primary-action` + understruken.
+- Använd inte accent-färger på text — bara på dekoration, taggar, grafer.
+- Statusbanner: använd `*-surface` som bakgrund + matchande `*-text` som textfärg.
 
 **Typografi**
 - Webb: `Verdana, sans-serif`.
-- iOS: `SF Pro` med iOS-typskalan i `tokens.json` (Large title 34 → Caption 2 11).
-- Android: `Roboto` (Material 3 type-skala).
+- iOS: SF Pro via `Font.system(...)` enligt iOS-typskalan i `tokens.json` (Large title 34 → Caption 2 11).
+- Android: Roboto (Material 3 type-skala).
 - Använd aldrig VGR Sans i digitala gränssnitt.
 
 **Spacing & layout**
-- Spacing: 4/8/12 (small), 24 (medium, mellan komponenter), 32 (large, mellan grupper). Safearea = 24.
+- Spacing: 4/8/12 inom komponent, 24 mellan komponenter (också safearea), 32 mellan grupper.
 - Breakpoints: mobil 320–768, tablet 768–1200, desktop 1200–1920.
 - Min komponentbredd innan breakpoint-fall: 220px.
 - Max 4 komponenter per rad (+ vänstermeny). Max 4 komponenter per innehållsarea.
 
 **Radier**
-- Sätts utifrån elementets bredd — större element, större radie.
-- Komponenter som hör ihop ska ha samma radie.
+- Större element = större radie. Komponenter som hör ihop ska ha samma radie.
 - När flera former möts: placera radien på det hörn som skapar mellanrumsformer.
 
-**Komponenter — välj alltid från manualen**
-Knapp, Länk, Länkikon, Tagg, Inputfält, Checkbox, Toggle, Tabs, Dropdown, Datumväljare, Toggle filter, Flervalsfilter med nivåer, Expanderbart block, Help button/box, Paginering, Callout/varning, Sökresultat, Sökträff, Nollträff, Artikel, Huvudmeny. För iOS finns dessutom Card, Callout-iOS, Text Formulär-iOS, Knappar-iOS. För Android: separata App-ikon-regler.
+**Komponenter — välj alltid från manualen / iOS-paketet**
 
-Bygg inga "egna" varianter av etablerade komponenter — utöka istället en befintlig med en ny prop/state efter att ha kontrollerat med användaren.
+För iOS finns dessa som färdiga `VGR`-prefixade SwiftUI-komponenter:
+Alerts, Buttons, Cards, Cells, Charts, Inputs, Labels, Layouts, Lists, Modals, Pickers, Popovers, Sliders, Tips. **Använd dem — bygg inte egna.**
+
+För webb finns dessa i manualen:
+Knapp, Länk, Länkikon, Tagg, Inputfält, Checkbox, Toggle, Tabs, Dropdown, Datumväljare, Toggle filter, Flervalsfilter med nivåer, Expanderbart block, Help button/box, Paginering, Callout/varning, Sökresultat, Sökträff, Nollträff, Artikel, Huvudmeny.
+
+Bygg inga "egna" varianter — utöka en befintlig med ny prop/state efter att ha kontrollerat med användaren.
 
 **Tillgänglighet (icke förhandlingsbart)**
 - WCAG 2.1 AA + DOS-lagen.
 - Tangentbordsnavigerbart med synlig focus.
-- Korrekta kontraster.
+- Korrekta kontraster (tokens är redan kontrastcheckade i sina semantiska par).
 - Klickbarhet ska synas (understrykning eller ikon).
-- Alltid `alt`-text på bilder.
-- Använd inte text i bilder.
+- Alltid `alt`-text på bilder. Använd inte text i bilder.
 - Testa mot VoiceOver (iOS), TalkBack (Android), NVDA/JAWS.
 
 **Klarspråk**
 - Vårdat, enkelt, begripligt språk anpassat efter målgrupp.
-- Texter ska gå att förstå även utan föregående kontext (användare kommer ofta direkt från sökmotor).
+- Texter ska gå att förstå även utan föregående kontext.
 
 ## När något saknas
-
-Om token, färgvärde eller komponent inte finns i `tokens.json`/`DESIGN_SYSTEM.md`:
 1. Slå upp i `SAKNAS.md`.
-2. Fråga användaren om värdet (eller om TBD-default kan användas).
-3. Föreslå aldrig hex-värden på egen hand utan att flagga att de är gissade.
+2. Kolla om värdet finns i `tokens-colors.json`.
+3. Som sista utväg: fråga användaren. Föreslå aldrig hex på egen hand.
 
 ## Output-format
 
-Föreslå default React + Tailwind, men följ alltid projektets befintliga val. Mappa tokens till:
-- Tailwind: konfigurera i `tailwind.config.js` så `bg-vgr-primary-base20` etc. fungerar.
-- Plain CSS: importera `tokens.css` och använd `var(--vgr-*)`.
-- iOS (SwiftUI): definiera `Color.vgrPrimaryBase20` osv. i `Tokens.swift`.
-- Android (Compose): definiera i `Color.kt` / `Theme.kt`.
+Bygger app från scratch — fråga först:
+- Plattform (iOS / Android / webb)
+- Webb-ramverk (React, Vue, vanilla, Svelte)
+- Tema-tonalitet (default = Primary blue/Healthcare)
+- Dark mode? (light + dark följer automatiskt med tokens.css)
+
+Mappning per stack:
+- **iOS:** lägg till Swift Package, importera `DesignSystem`, använd `VGRButton` etc.
+- **Tailwind:** generera `tailwind.config.js` från tokens (`bg-vgr-primary-action`, `text-vgr-neutral-text`).
+- **Plain CSS:** importera `tokens.css`, använd `var(--vgr-*)`.
+- **CSS-in-JS:** läs tokens-colors.json och bygg theme-objektet.
+- **Android Compose:** generera `Color.kt` + `Theme.kt` från tokens-colors.json (light + dark scheme).

--- a/.claude/skills/vgr-design/tokens-colors.json
+++ b/.claude/skills/vgr-design/tokens-colors.json
@@ -1,0 +1,383 @@
+{
+  "$source": "github.com/Vastra-Gotalandsregionen/designsystem-ios — Assets.xcassets/Colors. 92 tokens med light/dark.",
+  "accent": {
+    "brown": {
+      "light": "#6B5B55",
+      "dark": "#BAA7A1"
+    },
+    "browngraphic": {
+      "light": "#A48C83",
+      "dark": "#D0C4BF"
+    },
+    "brownsurface": {
+      "light": "#E7E1DF",
+      "dark": "#514440"
+    },
+    "brownsurfacebold": {
+      "light": "#D0C4BF",
+      "dark": "#A48C83"
+    },
+    "brownsurfacefixed": {
+      "light": "#E7E1DF",
+      "dark": "#E7E1DF"
+    },
+    "brownsurfaceminimal": {
+      "light": "#F3F0EF",
+      "dark": "#372F2B"
+    },
+    "cyan": {
+      "light": "#116875",
+      "dark": "#20BBD3"
+    },
+    "cyangraphic": {
+      "light": "#1A9FB3",
+      "dark": "#74D5E4"
+    },
+    "cyansurface": {
+      "light": "#BCEBF2",
+      "dark": "#0D4E58"
+    },
+    "cyansurfacebold": {
+      "light": "#74D5E4",
+      "dark": "#1A9FB3"
+    },
+    "cyansurfaceminimal": {
+      "light": "#DEF5F9",
+      "dark": "#09363C"
+    },
+    "green": {
+      "light": "#2C6B2E",
+      "dark": "#4FC254"
+    },
+    "greengraphic": {
+      "light": "#43A447",
+      "dark": "#7ADC7E"
+    },
+    "greensurface": {
+      "light": "#C0EEC2",
+      "dark": "#215023"
+    },
+    "greensurfacebold": {
+      "light": "#7ADC7E",
+      "dark": "#43A447"
+    },
+    "greensurfaceminimal": {
+      "light": "#E0F7E1",
+      "dark": "#173718"
+    },
+    "lime": {
+      "light": "#5C6321",
+      "dark": "#A7B33C"
+    },
+    "limegraphic": {
+      "light": "#8D9732",
+      "dark": "#CCDB49"
+    },
+    "limesurface": {
+      "light": "#E0E991",
+      "dark": "#454A19"
+    },
+    "limesurfacebold": {
+      "light": "#CCDB49",
+      "dark": "#8D9732"
+    },
+    "limesurfaceminimal": {
+      "light": "#EFF4C6",
+      "dark": "#2F3311"
+    },
+    "orange": {
+      "light": "#A63A1F",
+      "dark": "#FE8B6F"
+    },
+    "orangegraphic": {
+      "light": "#FC5930",
+      "dark": "#FEB5A2"
+    },
+    "orangesurface": {
+      "light": "#FFDBD2",
+      "dark": "#7D2C18"
+    },
+    "orangesurfacebold": {
+      "light": "#FEB5A2",
+      "dark": "#FC5930"
+    },
+    "orangesurfaceminimal": {
+      "light": "#FFEDE8",
+      "dark": "#561E10"
+    },
+    "pink": {
+      "light": "#B51D4E",
+      "dark": "#F28CAD"
+    },
+    "pinkgraphic": {
+      "light": "#EE6492",
+      "dark": "#F7BBD0"
+    },
+    "pinkgraphicfixed": {
+      "light": "#EE6492",
+      "dark": "#EE6492"
+    },
+    "pinksurface": {
+      "light": "#FBDAE5",
+      "dark": "#89163B"
+    },
+    "pinksurfacebold": {
+      "light": "#F7BBD0",
+      "dark": "#EE6492"
+    },
+    "pinksurfaceminimal": {
+      "light": "#FDEDF2",
+      "dark": "#600F29"
+    },
+    "purple": {
+      "light": "#6F45BB",
+      "dark": "#B7A1DD"
+    },
+    "purplegraphic": {
+      "light": "#9575CD",
+      "dark": "#D1C4E9"
+    },
+    "purplesurface": {
+      "light": "#E6DFF3",
+      "dark": "#553097"
+    },
+    "purplesurfacebold": {
+      "light": "#D1C4E9",
+      "dark": "#9575CD"
+    },
+    "purplesurfaceminimal": {
+      "light": "#F3EFF9",
+      "dark": "#3A2168"
+    },
+    "red": {
+      "light": "#C00000",
+      "dark": "#FF8888"
+    },
+    "redgraphic": {
+      "light": "#FF5353",
+      "dark": "#FFB3B3"
+    },
+    "redsurface": {
+      "light": "#FFDADA",
+      "dark": "#930000"
+    },
+    "redsurfacebold": {
+      "light": "#FFB3B3",
+      "dark": "#FF5353"
+    },
+    "redsurfaceminimal": {
+      "light": "#FFECEC",
+      "dark": "#690000"
+    },
+    "yellow": {
+      "light": "#8D4E18",
+      "dark": "#EF9820"
+    },
+    "yellowgraphic": {
+      "light": "#CF7E1F",
+      "dark": "#FFC107"
+    },
+    "yellowsurface": {
+      "light": "#FFDD84",
+      "dark": "#6D3912"
+    },
+    "yellowsurfacebold": {
+      "light": "#FFC107",
+      "dark": "#CF7E1F"
+    },
+    "yellowsurfaceminimal": {
+      "light": "#FFECB3",
+      "dark": "#4C270E"
+    }
+  },
+  "customized": {
+    "healthcare20": {
+      "light": "#04344D",
+      "dark": "#377495"
+    }
+  },
+  "elevation": {
+    "background": {
+      "light": "#FAF9F9",
+      "dark": "#000000"
+    },
+    "elevation1": {
+      "light": "#FFFFFF",
+      "dark": "#121212"
+    },
+    "elevation2": {
+      "light": "#FFFFFF",
+      "dark": "#303030"
+    },
+    "elevation3": {
+      "light": "#FFFFFF",
+      "dark": "#474747"
+    },
+    "elevation4": {
+      "light": "#FFFFFF",
+      "dark": "#5E5E5E"
+    },
+    "elevation5": {
+      "light": "#FFFFFF",
+      "dark": "#737373"
+    }
+  },
+  "neutral": {
+    "border": {
+      "light": "#121212",
+      "dark": "#F9F9F9"
+    },
+    "borderdisabled": {
+      "light": "#E2E2E2",
+      "dark": "#303030"
+    },
+    "disabled": {
+      "light": "#C6C6C6",
+      "dark": "#303030"
+    },
+    "disabledvariant": {
+      "light": "#F1F1F1",
+      "dark": "#5E5E5E"
+    },
+    "divider": {
+      "light": "#C6C6C6",
+      "dark": "#474747"
+    },
+    "dividervariant": {
+      "light": "#E2E2E2",
+      "dark": "#303030"
+    },
+    "surfacedisabled": {
+      "light": "#F1F1F1",
+      "dark": "#5E5E5E"
+    },
+    "text": {
+      "light": "#121212",
+      "dark": "#F9F9F9"
+    },
+    "textdisabled": {
+      "light": "#E2E2E2",
+      "dark": "#303030"
+    },
+    "textfixed": {
+      "light": "#121212",
+      "dark": "#121212"
+    },
+    "textinverted": {
+      "light": "#F9F9F9",
+      "dark": "#121212"
+    },
+    "textinvertedfixed": {
+      "light": "#F9F9F9",
+      "dark": "#F9F9F9"
+    },
+    "textvariant": {
+      "light": "#737373",
+      "dark": "#C6C6C6"
+    }
+  },
+  "primary": {
+    "action": {
+      "light": "#005B89",
+      "dark": "#8AB1C5"
+    },
+    "actionFixed": {
+      "light": "#005B89",
+      "dark": "#005B89"
+    },
+    "actioninverted": {
+      "light": "#EBF2F5",
+      "dark": "#04344D"
+    },
+    "actioninvertedfixed": {
+      "light": "#EBF2F5",
+      "dark": "#EBF2F5"
+    },
+    "actionvariant": {
+      "light": "#EBF2F5",
+      "dark": "#303030"
+    },
+    "base": {
+      "light": "#37474F",
+      "dark": "#A5ACB0"
+    },
+    "basegraphic": {
+      "light": "#899297",
+      "dark": "#C2C7CA"
+    },
+    "basesurface": {
+      "light": "#E0E3E4",
+      "dark": "#37474F"
+    },
+    "basesurfacebold": {
+      "light": "#C2C7CA",
+      "dark": "#6C787E"
+    },
+    "basesurfacefocus": {
+      "light": "#37474F",
+      "dark": "#A5ACB0"
+    },
+    "basesurfaceminimal": {
+      "light": "#F0F1F1",
+      "dark": "#273238"
+    },
+    "blue": {
+      "light": "#005B89",
+      "dark": "#8AB1C5"
+    },
+    "bluegraphic": {
+      "light": "#6497B3",
+      "dark": "#ADC8D6"
+    },
+    "bluesurface": {
+      "light": "#D7E4EC",
+      "dark": "#064B70"
+    },
+    "bluesurfacebold": {
+      "light": "#ADC8D6",
+      "dark": "#377495"
+    },
+    "bluesurfacefocus": {
+      "light": "#005B89",
+      "dark": "#8AB1C5"
+    },
+    "bluesurfaceminimal": {
+      "light": "#EBF2F5",
+      "dark": "#04344D"
+    }
+  },
+  "status": {
+    "errorsurface": {
+      "light": "#FFECEC",
+      "dark": "#690000"
+    },
+    "errortext": {
+      "light": "#C00000",
+      "dark": "#FF8888"
+    },
+    "informationsurface": {
+      "light": "#F3F0EF",
+      "dark": "#372F2B"
+    },
+    "informationtext": {
+      "light": "#6B5B55",
+      "dark": "#BAA7A1"
+    },
+    "successtext": {
+      "light": "#2C6B2E",
+      "dark": "#4FC254"
+    },
+    "successurface": {
+      "light": "#E0F7E1",
+      "dark": "#173718"
+    },
+    "warningsurface": {
+      "light": "#FFECB3",
+      "dark": "#4C270E"
+    },
+    "warningtext": {
+      "light": "#8D4E18",
+      "dark": "#EF9820"
+    }
+  }
+}

--- a/.claude/skills/vgr-design/tokens.css
+++ b/.claude/skills/vgr-design/tokens.css
@@ -1,0 +1,111 @@
+/* VGR Designsystem — CSS-variabler.
+   Källa: tokens.json (extraherat från manualen + Färgteman-PDF, 2026-05-22). */
+
+:root {
+  /* ---------- PRIMÄRFÄRG: Base ---------- */
+  --vgr-base-20: #273238;  /* mörk text/bakgrund */
+  --vgr-base-30: #37474F;  /* ★ varumärke */
+  --vgr-base-90: #E0E3E4;  /* ljus tonad yta */
+  --vgr-base-95: #F0F1F1;  /* default ljus bakgrund */
+
+  /* ---------- PRIMÄRFÄRGSTEMAN (välj ETT per app/verksamhet) ---------- */
+  /* Kultur */
+  --vgr-culture-30: #891D1D;
+  --vgr-culture-40: #C72A2A; /* ★ */
+  --vgr-culture-90: #F6DDDD;
+  --vgr-culture-95: #FAEEEE;
+
+  /* Utbildning */
+  --vgr-education-30: #005046;
+  --vgr-education-40: #00695C; /* ★ */
+  --vgr-education-90: #D5E6E4;
+  --vgr-education-95: #EAF2F1;
+
+  /* Sjukvård — default för vårdgränssnitt */
+  --vgr-healthcare-30: #064B70;
+  --vgr-healthcare-40: #005B89; /* ★ — också länkfärg i brödtext */
+  --vgr-healthcare-90: #D7E4EC;
+  --vgr-healthcare-95: #EBF2F5;
+
+  /* ---------- KOMPLEMENTFÄRGER (max 2 per app) ---------- */
+  --vgr-brown-80: #D0C4BF;
+  --vgr-brown-95: #F3F0EF;
+  --vgr-complement-healthcare-80: #ADC8D6;
+  --vgr-complement-healthcare-95: #EBF2F5;
+  --vgr-pink-80: #F7BBD0; /* ★ */
+  --vgr-pink-95: #FDEDF2;
+  --vgr-yellow-80: #FFC107; /* ★ */
+  --vgr-yellow-95: #FFECB3;
+
+  /* ---------- BAKGRUND ---------- */
+  --vgr-bg-warm:    #FAF9F9; /* Brown 99 — varm vit, ger lyft för vita ytor */
+  --vgr-bg-white:   #FFFFFF; /* Neutral 100 ★ */
+
+  /* ---------- SEMANTISKA ALIAS ----------
+     Mappa dessa per app baserat på vald verksamhet. Defaulten är Healthcare. */
+  --vgr-color-primary:        var(--vgr-healthcare-40);
+  --vgr-color-primary-dark:   var(--vgr-healthcare-30);
+  --vgr-color-primary-tint:   var(--vgr-healthcare-90);
+  --vgr-color-primary-soft:   var(--vgr-healthcare-95);
+  --vgr-color-link:           var(--vgr-healthcare-40);
+
+  /* Status */
+  --vgr-status-alarm:   var(--vgr-culture-40);
+  --vgr-status-warning: var(--vgr-yellow-80);
+  --vgr-status-info:    var(--vgr-base-30);
+  --vgr-status-success: var(--vgr-education-40);
+
+  /* ---------- TYPOGRAFI ---------- */
+  --vgr-font-web:     Verdana, sans-serif;
+  --vgr-font-ios:     "SF Pro", -apple-system, BlinkMacSystemFont, sans-serif;
+  --vgr-font-android: Roboto, sans-serif;
+
+  /* ---------- SPACING ---------- */
+  --vgr-space-xs: 4px;
+  --vgr-space-sm: 8px;
+  --vgr-space-md: 12px;
+  --vgr-space-lg: 24px;   /* mellan komponenter / safearea */
+  --vgr-space-xl: 32px;   /* mellan grupper */
+
+  /* ---------- RADIER ---------- */
+  --vgr-radius-sm: 4px;
+  --vgr-radius-md: 8px;
+  --vgr-radius-lg: 16px;
+  --vgr-radius-pill: 9999px;
+
+  /* ---------- ELEVATION ---------- */
+  --vgr-shadow-1: 0 1px 2px rgba(0,0,0,.06);
+  --vgr-shadow-2: 0 2px 6px rgba(0,0,0,.08);
+  --vgr-shadow-3: 0 8px 24px rgba(0,0,0,.12);
+
+  /* ---------- MOTION ---------- */
+  --vgr-motion-fast: 120ms;
+  --vgr-motion-base: 200ms;
+  --vgr-motion-slow: 320ms;
+  --vgr-ease-standard: cubic-bezier(.2,.0,.0,1);
+}
+
+/* ---------- TEMA-VARIANTER ----------
+   Lägg en av dessa klasser på <html> eller <body> för att byta primärfärgstema. */
+.theme-culture {
+  --vgr-color-primary:      var(--vgr-culture-40);
+  --vgr-color-primary-dark: var(--vgr-culture-30);
+  --vgr-color-primary-tint: var(--vgr-culture-90);
+  --vgr-color-primary-soft: var(--vgr-culture-95);
+}
+.theme-education {
+  --vgr-color-primary:      var(--vgr-education-40);
+  --vgr-color-primary-dark: var(--vgr-education-30);
+  --vgr-color-primary-tint: var(--vgr-education-90);
+  --vgr-color-primary-soft: var(--vgr-education-95);
+}
+.theme-healthcare {
+  --vgr-color-primary:      var(--vgr-healthcare-40);
+  --vgr-color-primary-dark: var(--vgr-healthcare-30);
+  --vgr-color-primary-tint: var(--vgr-healthcare-90);
+  --vgr-color-primary-soft: var(--vgr-healthcare-95);
+}
+
+/* ---------- BREAKPOINTS (referens) ----------
+   mobile: 320–768px | tablet: 768–1200px | desktop: 1200–1920px
+   min-bredd komponent: 220px | max komponenter per rad: 4 + vänstermeny */

--- a/.claude/skills/vgr-design/tokens.css
+++ b/.claude/skills/vgr-design/tokens.css
@@ -1,111 +1,241 @@
 /* VGR Designsystem — CSS-variabler.
-   Källa: tokens.json (extraherat från manualen + Färgteman-PDF, 2026-05-22). */
+   Källa: github.com/Vastra-Gotalandsregionen/designsystem-ios (Assets.xcassets).
+   92 färgtokens × light/dark. Dark mode via @media (prefers-color-scheme: dark). */
 
 :root {
-  /* ---------- PRIMÄRFÄRG: Base ---------- */
-  --vgr-base-20: #273238;  /* mörk text/bakgrund */
-  --vgr-base-30: #37474F;  /* ★ varumärke */
-  --vgr-base-90: #E0E3E4;  /* ljus tonad yta */
-  --vgr-base-95: #F0F1F1;  /* default ljus bakgrund */
+  /* ---- Primary ---- */
+  --vgr-primary-action: #005B89;
+  --vgr-primary-actionFixed: #005B89;
+  --vgr-primary-actioninverted: #EBF2F5;
+  --vgr-primary-actioninvertedfixed: #EBF2F5;
+  --vgr-primary-actionvariant: #EBF2F5;
+  --vgr-primary-base: #37474F;
+  --vgr-primary-basegraphic: #899297;
+  --vgr-primary-basesurface: #E0E3E4;
+  --vgr-primary-basesurfacebold: #C2C7CA;
+  --vgr-primary-basesurfacefocus: #37474F;
+  --vgr-primary-basesurfaceminimal: #F0F1F1;
+  --vgr-primary-blue: #005B89;
+  --vgr-primary-bluegraphic: #6497B3;
+  --vgr-primary-bluesurface: #D7E4EC;
+  --vgr-primary-bluesurfacebold: #ADC8D6;
+  --vgr-primary-bluesurfacefocus: #005B89;
+  --vgr-primary-bluesurfaceminimal: #EBF2F5;
 
-  /* ---------- PRIMÄRFÄRGSTEMAN (välj ETT per app/verksamhet) ---------- */
-  /* Kultur */
-  --vgr-culture-30: #891D1D;
-  --vgr-culture-40: #C72A2A; /* ★ */
-  --vgr-culture-90: #F6DDDD;
-  --vgr-culture-95: #FAEEEE;
+  /* ---- Neutral ---- */
+  --vgr-neutral-border: #121212;
+  --vgr-neutral-borderdisabled: #E2E2E2;
+  --vgr-neutral-disabled: #C6C6C6;
+  --vgr-neutral-disabledvariant: #F1F1F1;
+  --vgr-neutral-divider: #C6C6C6;
+  --vgr-neutral-dividervariant: #E2E2E2;
+  --vgr-neutral-surfacedisabled: #F1F1F1;
+  --vgr-neutral-text: #121212;
+  --vgr-neutral-textdisabled: #E2E2E2;
+  --vgr-neutral-textfixed: #121212;
+  --vgr-neutral-textinverted: #F9F9F9;
+  --vgr-neutral-textinvertedfixed: #F9F9F9;
+  --vgr-neutral-textvariant: #737373;
 
-  /* Utbildning */
-  --vgr-education-30: #005046;
-  --vgr-education-40: #00695C; /* ★ */
-  --vgr-education-90: #D5E6E4;
-  --vgr-education-95: #EAF2F1;
+  /* ---- Status ---- */
+  --vgr-status-errorsurface: #FFECEC;
+  --vgr-status-errortext: #C00000;
+  --vgr-status-informationsurface: #F3F0EF;
+  --vgr-status-informationtext: #6B5B55;
+  --vgr-status-successtext: #2C6B2E;
+  --vgr-status-successurface: #E0F7E1;
+  --vgr-status-warningsurface: #FFECB3;
+  --vgr-status-warningtext: #8D4E18;
 
-  /* Sjukvård — default för vårdgränssnitt */
-  --vgr-healthcare-30: #064B70;
-  --vgr-healthcare-40: #005B89; /* ★ — också länkfärg i brödtext */
-  --vgr-healthcare-90: #D7E4EC;
-  --vgr-healthcare-95: #EBF2F5;
+  /* ---- Accent ---- */
+  --vgr-accent-brown: #6B5B55;
+  --vgr-accent-browngraphic: #A48C83;
+  --vgr-accent-brownsurface: #E7E1DF;
+  --vgr-accent-brownsurfacebold: #D0C4BF;
+  --vgr-accent-brownsurfacefixed: #E7E1DF;
+  --vgr-accent-brownsurfaceminimal: #F3F0EF;
+  --vgr-accent-cyan: #116875;
+  --vgr-accent-cyangraphic: #1A9FB3;
+  --vgr-accent-cyansurface: #BCEBF2;
+  --vgr-accent-cyansurfacebold: #74D5E4;
+  --vgr-accent-cyansurfaceminimal: #DEF5F9;
+  --vgr-accent-green: #2C6B2E;
+  --vgr-accent-greengraphic: #43A447;
+  --vgr-accent-greensurface: #C0EEC2;
+  --vgr-accent-greensurfacebold: #7ADC7E;
+  --vgr-accent-greensurfaceminimal: #E0F7E1;
+  --vgr-accent-lime: #5C6321;
+  --vgr-accent-limegraphic: #8D9732;
+  --vgr-accent-limesurface: #E0E991;
+  --vgr-accent-limesurfacebold: #CCDB49;
+  --vgr-accent-limesurfaceminimal: #EFF4C6;
+  --vgr-accent-orange: #A63A1F;
+  --vgr-accent-orangegraphic: #FC5930;
+  --vgr-accent-orangesurface: #FFDBD2;
+  --vgr-accent-orangesurfacebold: #FEB5A2;
+  --vgr-accent-orangesurfaceminimal: #FFEDE8;
+  --vgr-accent-pink: #B51D4E;
+  --vgr-accent-pinkgraphic: #EE6492;
+  --vgr-accent-pinkgraphicfixed: #EE6492;
+  --vgr-accent-pinksurface: #FBDAE5;
+  --vgr-accent-pinksurfacebold: #F7BBD0;
+  --vgr-accent-pinksurfaceminimal: #FDEDF2;
+  --vgr-accent-purple: #6F45BB;
+  --vgr-accent-purplegraphic: #9575CD;
+  --vgr-accent-purplesurface: #E6DFF3;
+  --vgr-accent-purplesurfacebold: #D1C4E9;
+  --vgr-accent-purplesurfaceminimal: #F3EFF9;
+  --vgr-accent-red: #C00000;
+  --vgr-accent-redgraphic: #FF5353;
+  --vgr-accent-redsurface: #FFDADA;
+  --vgr-accent-redsurfacebold: #FFB3B3;
+  --vgr-accent-redsurfaceminimal: #FFECEC;
+  --vgr-accent-yellow: #8D4E18;
+  --vgr-accent-yellowgraphic: #CF7E1F;
+  --vgr-accent-yellowsurface: #FFDD84;
+  --vgr-accent-yellowsurfacebold: #FFC107;
+  --vgr-accent-yellowsurfaceminimal: #FFECB3;
 
-  /* ---------- KOMPLEMENTFÄRGER (max 2 per app) ---------- */
-  --vgr-brown-80: #D0C4BF;
-  --vgr-brown-95: #F3F0EF;
-  --vgr-complement-healthcare-80: #ADC8D6;
-  --vgr-complement-healthcare-95: #EBF2F5;
-  --vgr-pink-80: #F7BBD0; /* ★ */
-  --vgr-pink-95: #FDEDF2;
-  --vgr-yellow-80: #FFC107; /* ★ */
-  --vgr-yellow-95: #FFECB3;
+  /* ---- Elevation ---- */
+  --vgr-elevation-background: #FAF9F9;
+  --vgr-elevation-elevation1: #FFFFFF;
+  --vgr-elevation-elevation2: #FFFFFF;
+  --vgr-elevation-elevation3: #FFFFFF;
+  --vgr-elevation-elevation4: #FFFFFF;
+  --vgr-elevation-elevation5: #FFFFFF;
 
-  /* ---------- BAKGRUND ---------- */
-  --vgr-bg-warm:    #FAF9F9; /* Brown 99 — varm vit, ger lyft för vita ytor */
-  --vgr-bg-white:   #FFFFFF; /* Neutral 100 ★ */
+  /* ---- Customized ---- */
+  --vgr-customized-healthcare20: #04344D;
 
-  /* ---------- SEMANTISKA ALIAS ----------
-     Mappa dessa per app baserat på vald verksamhet. Defaulten är Healthcare. */
-  --vgr-color-primary:        var(--vgr-healthcare-40);
-  --vgr-color-primary-dark:   var(--vgr-healthcare-30);
-  --vgr-color-primary-tint:   var(--vgr-healthcare-90);
-  --vgr-color-primary-soft:   var(--vgr-healthcare-95);
-  --vgr-color-link:           var(--vgr-healthcare-40);
-
-  /* Status */
-  --vgr-status-alarm:   var(--vgr-culture-40);
-  --vgr-status-warning: var(--vgr-yellow-80);
-  --vgr-status-info:    var(--vgr-base-30);
-  --vgr-status-success: var(--vgr-education-40);
-
-  /* ---------- TYPOGRAFI ---------- */
-  --vgr-font-web:     Verdana, sans-serif;
-  --vgr-font-ios:     "SF Pro", -apple-system, BlinkMacSystemFont, sans-serif;
+  /* ---- Typografi ---- */
+  --vgr-font-web: Verdana, sans-serif;
+  --vgr-font-ios: -apple-system, BlinkMacSystemFont, 'SF Pro', sans-serif;
   --vgr-font-android: Roboto, sans-serif;
 
-  /* ---------- SPACING ---------- */
+  /* ---- Spacing ---- */
   --vgr-space-xs: 4px;
   --vgr-space-sm: 8px;
   --vgr-space-md: 12px;
-  --vgr-space-lg: 24px;   /* mellan komponenter / safearea */
-  --vgr-space-xl: 32px;   /* mellan grupper */
+  --vgr-space-lg: 24px;
+  --vgr-space-xl: 32px;
 
-  /* ---------- RADIER ---------- */
+  /* ---- Radier ---- */
   --vgr-radius-sm: 4px;
   --vgr-radius-md: 8px;
   --vgr-radius-lg: 16px;
   --vgr-radius-pill: 9999px;
 
-  /* ---------- ELEVATION ---------- */
-  --vgr-shadow-1: 0 1px 2px rgba(0,0,0,.06);
-  --vgr-shadow-2: 0 2px 6px rgba(0,0,0,.08);
-  --vgr-shadow-3: 0 8px 24px rgba(0,0,0,.12);
-
-  /* ---------- MOTION ---------- */
+  /* ---- Motion ---- */
   --vgr-motion-fast: 120ms;
   --vgr-motion-base: 200ms;
   --vgr-motion-slow: 320ms;
   --vgr-ease-standard: cubic-bezier(.2,.0,.0,1);
 }
 
-/* ---------- TEMA-VARIANTER ----------
-   Lägg en av dessa klasser på <html> eller <body> för att byta primärfärgstema. */
-.theme-culture {
-  --vgr-color-primary:      var(--vgr-culture-40);
-  --vgr-color-primary-dark: var(--vgr-culture-30);
-  --vgr-color-primary-tint: var(--vgr-culture-90);
-  --vgr-color-primary-soft: var(--vgr-culture-95);
-}
-.theme-education {
-  --vgr-color-primary:      var(--vgr-education-40);
-  --vgr-color-primary-dark: var(--vgr-education-30);
-  --vgr-color-primary-tint: var(--vgr-education-90);
-  --vgr-color-primary-soft: var(--vgr-education-95);
-}
-.theme-healthcare {
-  --vgr-color-primary:      var(--vgr-healthcare-40);
-  --vgr-color-primary-dark: var(--vgr-healthcare-30);
-  --vgr-color-primary-tint: var(--vgr-healthcare-90);
-  --vgr-color-primary-soft: var(--vgr-healthcare-95);
+/* ---- Dark mode ---- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* primary */
+    --vgr-primary-action: #8AB1C5;
+    --vgr-primary-actionFixed: #005B89;
+    --vgr-primary-actioninverted: #04344D;
+    --vgr-primary-actioninvertedfixed: #EBF2F5;
+    --vgr-primary-actionvariant: #303030;
+    --vgr-primary-base: #A5ACB0;
+    --vgr-primary-basegraphic: #C2C7CA;
+    --vgr-primary-basesurface: #37474F;
+    --vgr-primary-basesurfacebold: #6C787E;
+    --vgr-primary-basesurfacefocus: #A5ACB0;
+    --vgr-primary-basesurfaceminimal: #273238;
+    --vgr-primary-blue: #8AB1C5;
+    --vgr-primary-bluegraphic: #ADC8D6;
+    --vgr-primary-bluesurface: #064B70;
+    --vgr-primary-bluesurfacebold: #377495;
+    --vgr-primary-bluesurfacefocus: #8AB1C5;
+    --vgr-primary-bluesurfaceminimal: #04344D;
+    /* neutral */
+    --vgr-neutral-border: #F9F9F9;
+    --vgr-neutral-borderdisabled: #303030;
+    --vgr-neutral-disabled: #303030;
+    --vgr-neutral-disabledvariant: #5E5E5E;
+    --vgr-neutral-divider: #474747;
+    --vgr-neutral-dividervariant: #303030;
+    --vgr-neutral-surfacedisabled: #5E5E5E;
+    --vgr-neutral-text: #F9F9F9;
+    --vgr-neutral-textdisabled: #303030;
+    --vgr-neutral-textfixed: #121212;
+    --vgr-neutral-textinverted: #121212;
+    --vgr-neutral-textinvertedfixed: #F9F9F9;
+    --vgr-neutral-textvariant: #C6C6C6;
+    /* status */
+    --vgr-status-errorsurface: #690000;
+    --vgr-status-errortext: #FF8888;
+    --vgr-status-informationsurface: #372F2B;
+    --vgr-status-informationtext: #BAA7A1;
+    --vgr-status-successtext: #4FC254;
+    --vgr-status-successurface: #173718;
+    --vgr-status-warningsurface: #4C270E;
+    --vgr-status-warningtext: #EF9820;
+    /* accent */
+    --vgr-accent-brown: #BAA7A1;
+    --vgr-accent-browngraphic: #D0C4BF;
+    --vgr-accent-brownsurface: #514440;
+    --vgr-accent-brownsurfacebold: #A48C83;
+    --vgr-accent-brownsurfacefixed: #E7E1DF;
+    --vgr-accent-brownsurfaceminimal: #372F2B;
+    --vgr-accent-cyan: #20BBD3;
+    --vgr-accent-cyangraphic: #74D5E4;
+    --vgr-accent-cyansurface: #0D4E58;
+    --vgr-accent-cyansurfacebold: #1A9FB3;
+    --vgr-accent-cyansurfaceminimal: #09363C;
+    --vgr-accent-green: #4FC254;
+    --vgr-accent-greengraphic: #7ADC7E;
+    --vgr-accent-greensurface: #215023;
+    --vgr-accent-greensurfacebold: #43A447;
+    --vgr-accent-greensurfaceminimal: #173718;
+    --vgr-accent-lime: #A7B33C;
+    --vgr-accent-limegraphic: #CCDB49;
+    --vgr-accent-limesurface: #454A19;
+    --vgr-accent-limesurfacebold: #8D9732;
+    --vgr-accent-limesurfaceminimal: #2F3311;
+    --vgr-accent-orange: #FE8B6F;
+    --vgr-accent-orangegraphic: #FEB5A2;
+    --vgr-accent-orangesurface: #7D2C18;
+    --vgr-accent-orangesurfacebold: #FC5930;
+    --vgr-accent-orangesurfaceminimal: #561E10;
+    --vgr-accent-pink: #F28CAD;
+    --vgr-accent-pinkgraphic: #F7BBD0;
+    --vgr-accent-pinkgraphicfixed: #EE6492;
+    --vgr-accent-pinksurface: #89163B;
+    --vgr-accent-pinksurfacebold: #EE6492;
+    --vgr-accent-pinksurfaceminimal: #600F29;
+    --vgr-accent-purple: #B7A1DD;
+    --vgr-accent-purplegraphic: #D1C4E9;
+    --vgr-accent-purplesurface: #553097;
+    --vgr-accent-purplesurfacebold: #9575CD;
+    --vgr-accent-purplesurfaceminimal: #3A2168;
+    --vgr-accent-red: #FF8888;
+    --vgr-accent-redgraphic: #FFB3B3;
+    --vgr-accent-redsurface: #930000;
+    --vgr-accent-redsurfacebold: #FF5353;
+    --vgr-accent-redsurfaceminimal: #690000;
+    --vgr-accent-yellow: #EF9820;
+    --vgr-accent-yellowgraphic: #FFC107;
+    --vgr-accent-yellowsurface: #6D3912;
+    --vgr-accent-yellowsurfacebold: #CF7E1F;
+    --vgr-accent-yellowsurfaceminimal: #4C270E;
+    /* elevation */
+    --vgr-elevation-background: #000000;
+    --vgr-elevation-elevation1: #121212;
+    --vgr-elevation-elevation2: #303030;
+    --vgr-elevation-elevation3: #474747;
+    --vgr-elevation-elevation4: #5E5E5E;
+    --vgr-elevation-elevation5: #737373;
+    /* customized */
+    --vgr-customized-healthcare20: #377495;
+  }
 }
 
-/* ---------- BREAKPOINTS (referens) ----------
-   mobile: 320–768px | tablet: 768–1200px | desktop: 1200–1920px
-   min-bredd komponent: 220px | max komponenter per rad: 4 + vänstermeny */
+/* ---- Breakpoints (referens) ----
+   mobile: 320-768px | tablet: 768-1200px | desktop: 1200-1920px
+   min komponentbredd: 220px | max 4 komponenter/rad + vänstermeny */

--- a/.claude/skills/vgr-design/tokens.json
+++ b/.claude/skills/vgr-design/tokens.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "VGR Designsystem tokens — extraherat 2026-05-22 från designmanualens screenshots + Färgteman-PDF.",
+  "$model": "Färgsystemet bygger på en PRIMÄRFÄRG (Base) + ett verksamhetsspecifikt PRIMÄRFÄRGSTEMA (Culture/Education/Healthcare) + max 2 KOMPLEMENTFÄRGER (Brown/Pink/Yellow/Healthcare). ★ = varumärkesnyansen.",
+
+  "color": {
+    "base": {
+      "20":  { "value": "#273238", "rgb": [39, 50, 56],     "role": "Mörkaste primär — text på ljus yta, mörk bakgrund" },
+      "30":  { "value": "#37474F", "rgb": [55, 71, 79],     "role": "★ Primärfärgens varumärkesnyans (mellansteg)" },
+      "90":  { "value": "#E0E3E4", "rgb": [224, 227, 228],  "role": "Ljus tonad bakgrund / hover-ytor" },
+      "95":  { "value": "#F0F1F1", "rgb": [240, 241, 241],  "role": "Mycket ljus bakgrund (default 'utan färg')" }
+    },
+
+    "culture": {
+      "$role": "Primärfärgstema för verksamhet Kultur.",
+      "30":  { "value": "#891D1D", "rgb": [137, 29, 29] },
+      "40":  { "value": "#C72A2A", "rgb": [199, 42, 42],    "role": "★ Varumärkesnyans" },
+      "90":  { "value": "#F6DDDD", "rgb": [246, 221, 221] },
+      "95":  { "value": "#FAEEEE", "rgb": [250, 238, 238] }
+    },
+
+    "education": {
+      "$role": "Primärfärgstema för verksamhet Utbildning.",
+      "30":  { "value": "#005046", "rgb": [0, 80, 70] },
+      "40":  { "value": "#00695C", "rgb": [0, 105, 92],     "role": "★ Varumärkesnyans" },
+      "90":  { "value": "#D5E6E4", "rgb": [213, 230, 228] },
+      "95":  { "value": "#EAF2F1", "rgb": [234, 242, 241] }
+    },
+
+    "healthcare": {
+      "$role": "Primärfärgstema för verksamhet Sjukvård (default för vårdgränssnitt). Healthcare 40 används också som länkfärg i brödtext.",
+      "30":  { "value": "#064B70", "rgb": [6, 75, 112] },
+      "40":  { "value": "#005B89", "rgb": [0, 91, 137],     "role": "★ Varumärkesnyans. Länkfärg i brödtext." },
+      "90":  { "value": "#D7E4EC", "rgb": [215, 228, 236] },
+      "95":  { "value": "#EBF2F5", "rgb": [235, 242, 245] }
+    },
+
+    "complement": {
+      "$rule": "Max 2 komplementfärger i 2 nyanser till primärfärgen. Primärfärgen kan även väljas in som komplementfärg, förutsatt att man väljer primärfärg för rätt tillhörighet.",
+      "brown": {
+        "80":  { "value": "#D0C4BF", "rgb": [208, 196, 191] },
+        "95":  { "value": "#F3F0EF", "rgb": [243, 240, 239] }
+      },
+      "healthcare": {
+        "80":  { "value": "#ADC8D6", "rgb": [173, 200, 214] },
+        "95":  { "value": "#EBF2F5", "rgb": [235, 242, 245] }
+      },
+      "pink": {
+        "80":  { "value": "#F7BBD0", "rgb": [247, 187, 208], "role": "★ Varumärkesnyans" },
+        "95":  { "value": "#FDEDF2", "rgb": [253, 237, 242] }
+      },
+      "yellow": {
+        "80":  { "value": "#FFC107", "rgb": [255, 193, 7],   "role": "★ Varumärkesnyans" },
+        "95":  { "value": "#FFECB3", "rgb": [255, 236, 179] }
+      }
+    },
+
+    "background": {
+      "$note": "Brown 99 ger ett lyft för vita tryckbara ytor och tillför värme. Kan användas för diagram/icke-interaktiva ytor istället för rent vitt.",
+      "brown99":   { "value": "#FAF9F9", "rgb": [250, 249, 249], "role": "Bakgrundsfärg (varm vit)" },
+      "neutral100": { "value": "#FFFFFF", "rgb": [255, 255, 255], "role": "★ Vit" }
+    },
+
+    "text": {
+      "$note": "Textfärger används i Figma i komponenter och är där kontrastcheckade i den kontext de presenteras. Hex-värden för individuella text-tokens fångades inte i denna PDF — se SAKNAS.md.",
+      "primary":   "TBD",
+      "secondary": "TBD",
+      "inverse":   "TBD",
+      "link":      "#005B89",
+      "disabled":  "TBD"
+    },
+
+    "status": {
+      "$note": "Approximerade. Hämta exakta värden från manualen om de finns.",
+      "alarm":   { "value": "#C72A2A", "role": "Använder Culture 40 för fel/alarm i callout-banner" },
+      "warning": { "value": "#FFC107", "role": "Använder Yellow 80 för varning" },
+      "info":    { "value": "#37474F", "role": "Använder Base 30 för info" },
+      "success": { "value": "#00695C", "role": "Använder Education 40 för success" }
+    }
+  },
+
+  "typography": {
+    "fontFamily": {
+      "web":     "Verdana, sans-serif",
+      "ios":     "SF Pro",
+      "android": "Roboto",
+      "$brand":  "VGR Sans (ej för digitala gränssnitt — ersätts av Verdana på webb)"
+    },
+
+    "ios": {
+      "largeTitle": { "size": 34, "weight": "Bold",     "lineHeight": 41 },
+      "title1":     { "size": 28, "weight": "Bold",     "lineHeight": 34 },
+      "title2":     { "size": 22, "weight": "Bold",     "lineHeight": 28 },
+      "title3":     { "size": 20, "weight": "Bold",     "lineHeight": 25 },
+      "headline":   { "size": 17, "weight": "Semibold", "lineHeight": 22 },
+      "body":       { "size": 17, "weight": "Regular",  "lineHeight": 22 },
+      "callout":    { "size": 16, "weight": "Regular",  "lineHeight": 21 },
+      "subhead":    { "size": 15, "weight": "Regular",  "lineHeight": 20 },
+      "footnote":   { "size": 13, "weight": "Regular",  "lineHeight": 18 },
+      "caption1":   { "size": 12, "weight": "Semibold", "lineHeight": 16 },
+      "caption2":   { "size": 11, "weight": "Regular",  "lineHeight": 13 }
+    },
+
+    "web": {
+      "$note": "Webb-skalan saknas i fångat material — defaults nedan tills officiell skala finns.",
+      "h1":    { "size": "2.25rem", "weight": 700, "lineHeight": 1.2 },
+      "h2":    { "size": "1.75rem", "weight": 700, "lineHeight": 1.25 },
+      "h3":    { "size": "1.375rem","weight": 700, "lineHeight": 1.3 },
+      "h4":    { "size": "1.125rem","weight": 700, "lineHeight": 1.35 },
+      "body":  { "size": "1rem",    "weight": 400, "lineHeight": 1.5 },
+      "small": { "size": "0.875rem","weight": 400, "lineHeight": 1.45 }
+    }
+  },
+
+  "spacing": {
+    "xs":  4,
+    "sm":  8,
+    "md":  12,
+    "lg":  24,
+    "xl":  32,
+    "safeArea": 24,
+    "$rules": {
+      "small":   "4/8/12 — inom samma komponent (padding kring text i en kort).",
+      "medium":  "24 — mellan komponenter i samma grupp (grid-gap).",
+      "large":   "32 — mellan grupper / större delar.",
+      "safearea":"24 — minsta padding på sidorna av en webbsida."
+    }
+  },
+
+  "radius": {
+    "$rule": "Radien sätts utifrån elementets bredd — större bredd = större radie. Placera radien på det hörn som skapar mellanrumsformer. Komponenter som hör ihop ska ha samma radie. Undvik så liten radie att mellanrumsformerna blir otydliga.",
+    "sm": 4,
+    "md": 8,
+    "lg": 16,
+    "pill": 9999
+  },
+
+  "breakpoints": {
+    "mobile":   { "min": 320,  "max": 768 },
+    "tablet":   { "min": 768,  "max": 1200 },
+    "desktop":  { "min": 1200, "max": 1920 },
+    "componentMinWidth": 220,
+    "$rules": "Min-bredd komponent = 220px. Max komponenter per rad = 4 + vänstermeny."
+  },
+
+  "elevation": {
+    "$note": "Defaults — manualens elevation-flik var ej fångad.",
+    "0":  "none",
+    "1":  "0 1px 2px rgba(0,0,0,0.06)",
+    "2":  "0 2px 6px rgba(0,0,0,0.08)",
+    "3":  "0 8px 24px rgba(0,0,0,0.12)"
+  },
+
+  "motion": {
+    "$note": "Defaults — manualen anger inga motion tokens.",
+    "duration": { "fast": "120ms", "base": "200ms", "slow": "320ms" },
+    "easing":   { "standard": "cubic-bezier(.2,.0,.0,1)" }
+  }
+}

--- a/.claude/skills/vgr-design/tokens.json
+++ b/.claude/skills/vgr-design/tokens.json
@@ -1,91 +1,90 @@
 {
-  "$schema": "VGR Designsystem tokens — extraherat 2026-05-22 från designmanualens screenshots + Färgteman-PDF.",
-  "$model": "Färgsystemet bygger på en PRIMÄRFÄRG (Base) + ett verksamhetsspecifikt PRIMÄRFÄRGSTEMA (Culture/Education/Healthcare) + max 2 KOMPLEMENTFÄRGER (Brown/Pink/Yellow/Healthcare). ★ = varumärkesnyansen.",
+  "$source": "Värden hämtade direkt från github.com/Vastra-Gotalandsregionen/designsystem-ios (Assets.xcassets/Colors) — den officiella källan. Tidigare gissningar från screenshots ersatta.",
+  "$updated": "2026-05-22",
+  "$see_also": "tokens-colors.json innehåller HELA paletten (92 tokens × light/dark). Den här filen är en navigationsguide.",
 
   "color": {
-    "base": {
-      "20":  { "value": "#273238", "rgb": [39, 50, 56],     "role": "Mörkaste primär — text på ljus yta, mörk bakgrund" },
-      "30":  { "value": "#37474F", "rgb": [55, 71, 79],     "role": "★ Primärfärgens varumärkesnyans (mellansteg)" },
-      "90":  { "value": "#E0E3E4", "rgb": [224, 227, 228],  "role": "Ljus tonad bakgrund / hover-ytor" },
-      "95":  { "value": "#F0F1F1", "rgb": [240, 241, 241],  "role": "Mycket ljus bakgrund (default 'utan färg')" }
+    "$model": "Tokens grupperas i: Primary (varumärket — base + blue), Accent (10 färger × 5 roller = 50 tokens för dekoration/grafer), Neutral (text/border/divider/disabled), Status (error/warning/information/success med text+surface), Elevation (5 nivåer för dark mode).",
+
+    "primary": {
+      "$role": "Varumärkesfärger — base (mörkgrå) + blue (vården/Healthcare). 'action' är semantiskt alias för länk/knappfärg och pekar på blue.",
+      "base":          { "light": "#37474F", "dark": "#A5ACB0", "role": "Primärfärg ★" },
+      "basegraphic":   { "light": "#899297", "dark": "#C2C7CA" },
+      "basesurface":   { "light": "#E0E3E4", "dark": "#37474F" },
+      "basesurfacebold":   { "light": "#C2C7CA", "dark": "#6C787E" },
+      "basesurfacefocus":  { "light": "#37474F", "dark": "#A5ACB0" },
+      "basesurfaceminimal":{ "light": "#F0F1F1", "dark": "#273238" },
+
+      "blue":          { "light": "#005B89", "dark": "#8AB1C5", "role": "Healthcare ★" },
+      "bluegraphic":   { "light": "#6497B3", "dark": "#ADC8D6" },
+      "bluesurface":   { "light": "#D7E4EC", "dark": "#064B70" },
+      "bluesurfacebold":   { "light": "#ADC8D6", "dark": "#377495" },
+      "bluesurfacefocus":  { "light": "#005B89", "dark": "#8AB1C5" },
+      "bluesurfaceminimal":{ "light": "#EBF2F5", "dark": "#04344D" },
+
+      "action":             { "light": "#005B89", "dark": "#8AB1C5", "role": "Länk/knappfärg" },
+      "actionFixed":        { "light": "#005B89", "dark": "#005B89" },
+      "actioninverted":     { "light": "#EBF2F5", "dark": "#04344D" },
+      "actioninvertedfixed":{ "light": "#EBF2F5", "dark": "#EBF2F5" },
+      "actionvariant":      { "light": "#EBF2F5", "dark": "#303030" }
     },
 
-    "culture": {
-      "$role": "Primärfärgstema för verksamhet Kultur.",
-      "30":  { "value": "#891D1D", "rgb": [137, 29, 29] },
-      "40":  { "value": "#C72A2A", "rgb": [199, 42, 42],    "role": "★ Varumärkesnyans" },
-      "90":  { "value": "#F6DDDD", "rgb": [246, 221, 221] },
-      "95":  { "value": "#FAEEEE", "rgb": [250, 238, 238] }
-    },
-
-    "education": {
-      "$role": "Primärfärgstema för verksamhet Utbildning.",
-      "30":  { "value": "#005046", "rgb": [0, 80, 70] },
-      "40":  { "value": "#00695C", "rgb": [0, 105, 92],     "role": "★ Varumärkesnyans" },
-      "90":  { "value": "#D5E6E4", "rgb": [213, 230, 228] },
-      "95":  { "value": "#EAF2F1", "rgb": [234, 242, 241] }
-    },
-
-    "healthcare": {
-      "$role": "Primärfärgstema för verksamhet Sjukvård (default för vårdgränssnitt). Healthcare 40 används också som länkfärg i brödtext.",
-      "30":  { "value": "#064B70", "rgb": [6, 75, 112] },
-      "40":  { "value": "#005B89", "rgb": [0, 91, 137],     "role": "★ Varumärkesnyans. Länkfärg i brödtext." },
-      "90":  { "value": "#D7E4EC", "rgb": [215, 228, 236] },
-      "95":  { "value": "#EBF2F5", "rgb": [235, 242, 245] }
-    },
-
-    "complement": {
-      "$rule": "Max 2 komplementfärger i 2 nyanser till primärfärgen. Primärfärgen kan även väljas in som komplementfärg, förutsatt att man väljer primärfärg för rätt tillhörighet.",
-      "brown": {
-        "80":  { "value": "#D0C4BF", "rgb": [208, 196, 191] },
-        "95":  { "value": "#F3F0EF", "rgb": [243, 240, 239] }
-      },
-      "healthcare": {
-        "80":  { "value": "#ADC8D6", "rgb": [173, 200, 214] },
-        "95":  { "value": "#EBF2F5", "rgb": [235, 242, 245] }
-      },
-      "pink": {
-        "80":  { "value": "#F7BBD0", "rgb": [247, 187, 208], "role": "★ Varumärkesnyans" },
-        "95":  { "value": "#FDEDF2", "rgb": [253, 237, 242] }
-      },
-      "yellow": {
-        "80":  { "value": "#FFC107", "rgb": [255, 193, 7],   "role": "★ Varumärkesnyans" },
-        "95":  { "value": "#FFECB3", "rgb": [255, 236, 179] }
-      }
-    },
-
-    "background": {
-      "$note": "Brown 99 ger ett lyft för vita tryckbara ytor och tillför värme. Kan användas för diagram/icke-interaktiva ytor istället för rent vitt.",
-      "brown99":   { "value": "#FAF9F9", "rgb": [250, 249, 249], "role": "Bakgrundsfärg (varm vit)" },
-      "neutral100": { "value": "#FFFFFF", "rgb": [255, 255, 255], "role": "★ Vit" }
-    },
-
-    "text": {
-      "$note": "Textfärger används i Figma i komponenter och är där kontrastcheckade i den kontext de presenteras. Hex-värden för individuella text-tokens fångades inte i denna PDF — se SAKNAS.md.",
-      "primary":   "TBD",
-      "secondary": "TBD",
-      "inverse":   "TBD",
-      "link":      "#005B89",
-      "disabled":  "TBD"
+    "neutral": {
+      "$role": "Text, ramar, dividers, disabled-states. Auto-anpassas till dark mode.",
+      "text":              { "light": "#121212", "dark": "#F9F9F9" },
+      "textvariant":       { "light": "#737373", "dark": "#C6C6C6", "role": "Sekundär text" },
+      "textfixed":         { "light": "#121212", "dark": "#121212" },
+      "textinverted":      { "light": "#F9F9F9", "dark": "#121212" },
+      "textinvertedfixed": { "light": "#F9F9F9", "dark": "#F9F9F9" },
+      "textdisabled":      { "light": "#E2E2E2", "dark": "#303030" },
+      "border":            { "light": "#121212", "dark": "#F9F9F9" },
+      "borderdisabled":    { "light": "#E2E2E2", "dark": "#303030" },
+      "divider":           { "light": "#C6C6C6", "dark": "#474747" },
+      "dividervariant":    { "light": "#E2E2E2", "dark": "#303030" },
+      "disabled":          { "light": "#C6C6C6", "dark": "#303030" },
+      "disabledvariant":   { "light": "#F1F1F1", "dark": "#5E5E5E" },
+      "surfacedisabled":   { "light": "#F1F1F1", "dark": "#5E5E5E" }
     },
 
     "status": {
-      "$note": "Approximerade. Hämta exakta värden från manualen om de finns.",
-      "alarm":   { "value": "#C72A2A", "role": "Använder Culture 40 för fel/alarm i callout-banner" },
-      "warning": { "value": "#FFC107", "role": "Använder Yellow 80 för varning" },
-      "info":    { "value": "#37474F", "role": "Använder Base 30 för info" },
-      "success": { "value": "#00695C", "role": "Använder Education 40 för success" }
+      "$role": "Error/warning/information/success — alltid par av text + surface.",
+      "errortext":         { "light": "#C00000", "dark": "#FF8888" },
+      "errorsurface":      { "light": "#FFECEC", "dark": "#690000" },
+      "warningtext":       { "light": "#8D4E18", "dark": "#EF9820" },
+      "warningsurface":    { "light": "#FFECB3", "dark": "#4C270E" },
+      "informationtext":   { "light": "#6B5B55", "dark": "#BAA7A1" },
+      "informationsurface":{ "light": "#F3F0EF", "dark": "#372F2B" },
+      "successtext":       { "light": "#2C6B2E", "dark": "#4FC254" },
+      "successurface":     { "light": "#E0F7E1", "dark": "#173718" }
+    },
+
+    "accent": {
+      "$role": "10 accentfärger — varje färg har 5 roller: bas, graphic, surface, surfacebold, surfaceminimal. Används för dekoration, kategorisering, grafer. Fullständig palett i tokens-colors.json.",
+      "$colors": ["brown","cyan","green","lime","orange","pink","purple","red","yellow"],
+      "$roles":  ["base (text/icon)","graphic (diagram)","surface (bakgrund)","surfacebold (kraftig)","surfaceminimal (svag)"]
+    },
+
+    "elevation": {
+      "$role": "5 nivåer för bakgrund/lyft. I light mode är allt vitt (skuggor särskiljer); i dark mode är de gradvis ljusare grå.",
+      "background": { "light": "#FAF9F9", "dark": "#000000", "role": "Sidbakgrund (Brown 99 från manualen)" },
+      "elevation1": { "light": "#FFFFFF", "dark": "#121212" },
+      "elevation2": { "light": "#FFFFFF", "dark": "#303030" },
+      "elevation3": { "light": "#FFFFFF", "dark": "#474747" },
+      "elevation4": { "light": "#FFFFFF", "dark": "#5E5E5E" },
+      "elevation5": { "light": "#FFFFFF", "dark": "#737373" }
+    },
+
+    "customized": {
+      "healthcare20": { "light": "#04344D", "dark": "#377495" }
     }
   },
 
   "typography": {
     "fontFamily": {
       "web":     "Verdana, sans-serif",
-      "ios":     "SF Pro",
-      "android": "Roboto",
-      "$brand":  "VGR Sans (ej för digitala gränssnitt — ersätts av Verdana på webb)"
+      "ios":     "SF Pro (system via Font.system)",
+      "android": "Roboto"
     },
-
     "ios": {
       "largeTitle": { "size": 34, "weight": "Bold",     "lineHeight": 41 },
       "title1":     { "size": 28, "weight": "Bold",     "lineHeight": 34 },
@@ -99,9 +98,8 @@
       "caption1":   { "size": 12, "weight": "Semibold", "lineHeight": 16 },
       "caption2":   { "size": 11, "weight": "Regular",  "lineHeight": 13 }
     },
-
     "web": {
-      "$note": "Webb-skalan saknas i fångat material — defaults nedan tills officiell skala finns.",
+      "$note": "Defaults — manualens officiella webbskala saknas fortfarande.",
       "h1":    { "size": "2.25rem", "weight": 700, "lineHeight": 1.2 },
       "h2":    { "size": "1.75rem", "weight": 700, "lineHeight": 1.25 },
       "h3":    { "size": "1.375rem","weight": 700, "lineHeight": 1.3 },
@@ -112,42 +110,19 @@
   },
 
   "spacing": {
-    "xs":  4,
-    "sm":  8,
-    "md":  12,
-    "lg":  24,
-    "xl":  32,
-    "safeArea": 24,
-    "$rules": {
-      "small":   "4/8/12 — inom samma komponent (padding kring text i en kort).",
-      "medium":  "24 — mellan komponenter i samma grupp (grid-gap).",
-      "large":   "32 — mellan grupper / större delar.",
-      "safearea":"24 — minsta padding på sidorna av en webbsida."
-    }
+    "xs": 4, "sm": 8, "md": 12, "lg": 24, "xl": 32, "safeArea": 24,
+    "$rules": "4/8/12 (inom komponent), 24 (mellan komponenter, safearea), 32 (mellan grupper)."
   },
 
-  "radius": {
-    "$rule": "Radien sätts utifrån elementets bredd — större bredd = större radie. Placera radien på det hörn som skapar mellanrumsformer. Komponenter som hör ihop ska ha samma radie. Undvik så liten radie att mellanrumsformerna blir otydliga.",
-    "sm": 4,
-    "md": 8,
-    "lg": 16,
-    "pill": 9999
+  "radius": { "sm": 4, "md": 8, "lg": 16, "pill": 9999,
+    "$rule": "Större element = större radie. Komponenter som hör ihop ska ha samma radie."
   },
 
   "breakpoints": {
     "mobile":   { "min": 320,  "max": 768 },
     "tablet":   { "min": 768,  "max": 1200 },
     "desktop":  { "min": 1200, "max": 1920 },
-    "componentMinWidth": 220,
-    "$rules": "Min-bredd komponent = 220px. Max komponenter per rad = 4 + vänstermeny."
-  },
-
-  "elevation": {
-    "$note": "Defaults — manualens elevation-flik var ej fångad.",
-    "0":  "none",
-    "1":  "0 1px 2px rgba(0,0,0,0.06)",
-    "2":  "0 2px 6px rgba(0,0,0,0.08)",
-    "3":  "0 8px 24px rgba(0,0,0,0.12)"
+    "componentMinWidth": 220
   },
 
   "motion": {


### PR DESCRIPTION
## Summary
- Adds a self-contained Claude Code skill at `.claude/skills/vgr-design/`
- Loads VGR design tokens, component specs and a11y rules before generating UI code
- Triggers automatically when a request mentions VGR or Vastra Gotalandsregionen

## Contents
- `SKILL.md` — instructions + rules
- `tokens.json` / `tokens.css` — full color themes (Base, Culture, Education, Healthcare) + complement palette, typography, spacing, radii, breakpoints
- `DESIGN_SYSTEM.md` — component & layout reference
- `SAKNAS.md` — known gaps (text colors, web type scale, motion tokens)

## Test plan
- [ ] Open the repo in a fresh Claude Code session
- [ ] Confirm `vgr-design` appears in the available skills list
- [ ] Ask "bygg en sida i VGR-stil" and verify the skill activates and reads tokens